### PR TITLE
Add Logs button to About page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -183,7 +183,10 @@ jobs:
           fi
 
           ZIP_FILE="build/Vigil-ant-${VERSION}.zip"
-          SIGNATURE=$(echo "$SPARKLE_PRIVATE_KEY" | "$SIGN_UPDATE" "$ZIP_FILE" --ed-key-file -)
+          RAW_OUTPUT=$(echo "$SPARKLE_PRIVATE_KEY" | "$SIGN_UPDATE" "$ZIP_FILE" --ed-key-file -)
+          # sign_update outputs: sparkle:edSignature="<sig>" length="<len>"
+          # Extract just the base64 signature value
+          SIGNATURE=$(echo "$RAW_OUTPUT" | sed -n 's/.*sparkle:edSignature="\([^"]*\)".*/\1/p')
           echo "signature=${SIGNATURE}" >> "$GITHUB_OUTPUT"
         id: sparkle
 

--- a/App/Views/AboutTab.swift
+++ b/App/Views/AboutTab.swift
@@ -79,6 +79,15 @@ struct AboutTab: View {
                 Button("Licenses") {
                     showingLicenses = true
                 }
+
+                Button("Logs") {
+                    let command = "log stream --predicate 'subsystem == \"net.shashankshekhar.vigilant\"' --level debug"
+                    let source = "tell application \"Terminal\"\nactivate\ndo script \"\(command)\"\nend tell"
+                    if let script = NSAppleScript(source: source) {
+                        var error: NSDictionary?
+                        script.executeAndReturnError(&error)
+                    }
+                }
             }
             .font(.subheadline)
 

--- a/appcast.xml
+++ b/appcast.xml
@@ -5,42 +5,6 @@
         <description>Vigil-ant update feed</description>
         <language>en</language>
         <item>
-            <title>Version 0.0.1</title>
-            <pubDate>Wed, 15 Apr 2026 05:47:28 +0000</pubDate>
-            <sparkle:version>0.0.1</sparkle:version>
-            <sparkle:shortVersionString>0.0.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <enclosure
-                url="https://github.com/shashank-shekhar/vigil-ant/releases/download/v0.0.1/Vigil-ant-0.0.1.zip"
-                length="2365282"
-                type="application/octet-stream"
-                sparkle:edSignature="sparkle:edSignature="t59LumWOJyFPI2zZdmXKlzloEByGsOzI2F5XU1xO7LI93gmGIawdTspruB0aiqT82qmeLo6JGxXlfFRxvAZIBg==" length="2365282"" />
-        </item>
-        <item>
-            <title>Version 0.0.1</title>
-            <pubDate>Wed, 15 Apr 2026 05:58:57 +0000</pubDate>
-            <sparkle:version>0.0.1</sparkle:version>
-            <sparkle:shortVersionString>0.0.1</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <enclosure
-                url="https://github.com/shashank-shekhar/vigil-ant/releases/download/v0.0.1/Vigil-ant-0.0.1.zip"
-                length="2365282"
-                type="application/octet-stream"
-                sparkle:edSignature="sparkle:edSignature="6qQnt6tf83zogESD3wJl0W6dnevlXsmDn2dUSmU8HUWJboRi0jW4jwgKi0harCDDynpx6V3+oMA4eTaUIeduCA==" length="2365282"" />
-        </item>
-        <item>
-            <title>Version 0.0.2</title>
-            <pubDate>Wed, 15 Apr 2026 22:49:46 +0000</pubDate>
-            <sparkle:version>0.0.2</sparkle:version>
-            <sparkle:shortVersionString>0.0.2</sparkle:shortVersionString>
-            <sparkle:minimumSystemVersion>14.0</sparkle:minimumSystemVersion>
-            <enclosure
-                url="https://github.com/shashank-shekhar/vigil-ant/releases/download/v0.0.2/Vigil-ant-0.0.2.zip"
-                length="2365282"
-                type="application/octet-stream"
-                sparkle:edSignature="sparkle:edSignature="a2BKGHpSXj4h/QnBibx5j1LOI5Q0DmMhq3+fiCt1iD4ysqPnvZHRo7/eWH7kmJJlCgZPaAuElrs/SxU7ppLIBg==" length="2365282"" />
-        </item>
-        <item>
             <title>Version 0.0.2</title>
             <pubDate>Thu, 16 Apr 2026 01:21:43 +0000</pubDate>
             <sparkle:version>0.0.2</sparkle:version>
@@ -50,7 +14,7 @@
                 url="https://github.com/shashank-shekhar/vigil-ant/releases/download/v0.0.2/Vigil-ant-0.0.2.zip"
                 length="2435523"
                 type="application/octet-stream"
-                sparkle:edSignature="sparkle:edSignature="DfBbOCqQ8rgIiJFHX2mdYdnrpaTljDrBZItyVMR/Y39kVvU7fNjbLsHHZoTYaoptbjPWHRHY44huQ8Mnx5/nBw==" length="2435523"" />
+                sparkle:edSignature="DfBbOCqQ8rgIiJFHX2mdYdnrpaTljDrBZItyVMR/Y39kVvU7fNjbLsHHZoTYaoptbjPWHRHY44huQ8Mnx5/nBw==" />
         </item>
     </channel>
 </rss>


### PR DESCRIPTION
## Summary
- Adds a "Logs" button to the About page alongside GitHub and Licenses
- Opens Terminal with a live `log stream` filtered to the app's subsystem (`net.shashankshekhar.vigilant`)
- Uses AppleScript to launch Terminal (app is not sandboxed)

Closes #5

## Test plan
- [ ] Click Logs button — Terminal opens with filtered log stream
- [ ] Verify logs from the app appear in the stream
- [ ] Verify other app logs are excluded