### PR TITLE
Show welcome screen when all accounts removed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,12 +57,10 @@ jobs:
       - name: Set app version from tag
         env:
           VERSION: ${{ steps.version.outputs.version }}
+          BUILD_NUMBER: ${{ github.run_number }}
         run: |
-          # Extract major.minor.patch for MARKETING_VERSION and build number
           sed -i '' "s/MARKETING_VERSION = .*/MARKETING_VERSION = ${VERSION};/" \
             Vigilant/Vigilant.xcodeproj/project.pbxproj
-          # Use version components as build number (e.g., 0.0.2 → integer via date+run)
-          BUILD_NUMBER=$(date +%Y%m%d%H%M)
           sed -i '' "s/CURRENT_PROJECT_VERSION = .*/CURRENT_PROJECT_VERSION = ${BUILD_NUMBER};/" \
             Vigilant/Vigilant.xcodeproj/project.pbxproj
 

--- a/App/StatusBar/PopoverView.swift
+++ b/App/StatusBar/PopoverView.swift
@@ -16,7 +16,7 @@ struct PopoverView: View {
     private var aggregator: StatusAggregator { appState.aggregator }
 
     private var showWelcome: Bool {
-        return appState.accounts.isEmpty && !appState.hasCompletedOnboarding
+        return appState.accounts.isEmpty
     }
 
     var body: some View {

--- a/App/Views/AboutTab.swift
+++ b/App/Views/AboutTab.swift
@@ -22,6 +22,8 @@ struct AboutTab: View {
         Bundle.main.infoDictionary?["GIT_COMMIT_HASH"] as? String ?? ""
     }
 
+    private static let repoURL = "https://github.com/shashank-shekhar/vigil-ant"
+
     private var appName: String {
         Bundle.main.infoDictionary?["CFBundleDisplayName"] as? String ?? "Vigil-ant"
     }
@@ -42,8 +44,21 @@ struct AboutTab: View {
                 Text("Version \(appVersion)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
+                    .underline()
+                    .onTapGesture {
+                        NSWorkspace.shared.open(
+                            URL(string: "\(Self.repoURL)/releases/tag/v\(appVersion)")!
+                        )
+                    }
+                    .onHover { hovering in
+                        if hovering {
+                            NSCursor.pointingHand.push()
+                        } else {
+                            NSCursor.pop()
+                        }
+                    }
 
-                Text("Build \(buildNumber)")
+                Text("Build #\(buildNumber)")
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
 
@@ -54,7 +69,7 @@ struct AboutTab: View {
                         .underline()
                         .onTapGesture {
                             NSWorkspace.shared.open(
-                                URL(string: "https://github.com/shashank-shekhar/vigil-ant/commit/\(commitHash)")!
+                                URL(string: "\(Self.repoURL)/commit/\(commitHash)")!
                             )
                         }
                         .onHover { hovering in
@@ -80,7 +95,7 @@ struct AboutTab: View {
 
             HStack(spacing: 12) {
                 Button("GitHub") {
-                    NSWorkspace.shared.open(URL(string: "https://github.com/shashank-shekhar/vigil-ant")!)
+                    NSWorkspace.shared.open(URL(string: Self.repoURL)!)
                 }
 
                 Button("Licenses") {


### PR DESCRIPTION
## Summary
- Show welcome screen when all accounts are removed (was showing blank screen)
- Version text on About page is now clickable — links to GitHub release page
- Build number uses `github.run_number` instead of timestamp
- Extracted hardcoded repo URL into a single constant

Closes #9

## Test plan
- [ ] Remove all accounts — verify welcome screen appears
- [ ] Re-add an account — verify normal view returns
- [ ] Click version on About page — verify it opens the release page
- [ ] Verify build number shows as `Build #N` (next release)