### PR TITLE
Reorganize diagnostics in Settings (#11)

### DIFF
--- a/App/Views/AboutTab.swift
+++ b/App/Views/AboutTab.swift
@@ -1,14 +1,8 @@
-import OSLog
 import SwiftUI
 
 struct AboutTab: View {
+    var sparkleUpdater: SparkleUpdater
     @State private var showingLicenses = false
-    @State private var logsCopyState: LogsCopyState = .idle
-
-    private enum LogsCopyState {
-        case idle, copying, copied
-    }
-    @State private var filterCopied = false
 
     private var appVersion: String {
         Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "Unknown"
@@ -104,23 +98,10 @@ struct AboutTab: View {
                     showingLicenses = true
                 }
 
-                Button(logsCopyLabel) {
-                    copyCurrentSessionLogs()
+                Button("Check for Updates…") {
+                    sparkleUpdater.checkForUpdates()
                 }
-                .disabled(logsCopyState == .copying)
-
-                Button(filterCopied ? "Filter copied!" : "Console") {
-                    let subsystem = Bundle.main.bundleIdentifier ?? "net.shashankshekhar.vigilant"
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString("subsystem:\(subsystem)", forType: .string)
-                    filterCopied = true
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                        NSWorkspace.shared.open(
-                            URL(fileURLWithPath: "/System/Applications/Utilities/Console.app")
-                        )
-                        filterCopied = false
-                    }
-                }
+                .disabled(!sparkleUpdater.canCheckForUpdates)
             }
             .font(.subheadline)
             .padding(.bottom, 8)
@@ -129,44 +110,6 @@ struct AboutTab: View {
         .padding(16)
         .sheet(isPresented: $showingLicenses) {
             LicensesView()
-        }
-    }
-
-    private var logsCopyLabel: String {
-        switch logsCopyState {
-        case .idle: "Copy Logs"
-        case .copying: "Copying\u{2026}"
-        case .copied: "Copied!"
-        }
-    }
-
-    private func copyCurrentSessionLogs() {
-        logsCopyState = .copying
-        Task.detached {
-            do {
-                let store = try OSLogStore(scope: .currentProcessIdentifier)
-                let position = store.position(timeIntervalSinceLatestBoot: 0)
-                let entries = try store.getEntries(at: position)
-                    .compactMap { $0 as? OSLogEntryLog }
-                    .map { "[\($0.date.formatted(.iso8601))] [\($0.category)] \($0.composedMessage)" }
-
-                let text = entries.joined(separator: "\n")
-                await MainActor.run {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(text.isEmpty ? "No logs found for this session." : text, forType: .string)
-                    logsCopyState = .copied
-                }
-            } catch {
-                await MainActor.run {
-                    NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString("Failed to read logs: \(error.localizedDescription)", forType: .string)
-                    logsCopyState = .copied
-                }
-            }
-            try? await Task.sleep(for: .seconds(2))
-            await MainActor.run {
-                logsCopyState = .idle
-            }
         }
     }
 }

--- a/App/Views/GeneralTab.swift
+++ b/App/Views/GeneralTab.swift
@@ -1,3 +1,4 @@
+import OSLog
 import SwiftUI
 import ServiceManagement
 import KeyboardShortcuts
@@ -9,10 +10,16 @@ struct GeneralTab: View {
     @Bindable var appState: AppState
     var sparkleUpdater: SparkleUpdater
     @State private var launchAtLogin = false
+    @State private var logsCopyState: LogsCopyState = .idle
+    @State private var consoleFilterCopied = false
     @AppStorage("showNotifications") private var showNotifications = true
     @AppStorage("notifyOnFailure") private var notifyOnFailure = true
     @AppStorage("notifyOnFixed") private var notifyOnFixed = true
     @AppStorage("notifyGrouping") private var notifyGrouping = true
+
+    private enum LogsCopyState {
+        case idle, copying, copied
+    }
 
     var body: some View {
         Form {
@@ -61,16 +68,84 @@ struct GeneralTab: View {
                     get: { sparkleUpdater.automaticallyChecksForUpdates },
                     set: { sparkleUpdater.automaticallyChecksForUpdates = $0 }
                 ))
-                Button("Check for Updates…") {
-                    sparkleUpdater.checkForUpdates()
+            }
+
+            Section("Diagnostics") {
+                LabeledContent {
+                    Button(logsCopyLabel) {
+                        copyCurrentSessionLogs()
+                    }
+                    .disabled(logsCopyState == .copying)
+                } label: {
+                    Text("Copies this session's logs to your clipboard.")
+                        .foregroundStyle(.secondary)
                 }
-                .disabled(!sparkleUpdater.canCheckForUpdates)
+
+                LabeledContent {
+                    Button(consoleFilterCopied ? "Filter copied!" : "Open Console") {
+                        openConsoleWithFilter()
+                    }
+                } label: {
+                    Text("Copies a subsystem filter to your clipboard — paste it into Console's search field.")
+                        .foregroundStyle(.secondary)
+                }
             }
         }
         .formStyle(.grouped)
         .padding(16)
         .onAppear {
             launchAtLogin = SMAppService.mainApp.status == .enabled
+        }
+    }
+
+    private func openConsoleWithFilter() {
+        let subsystem = Bundle.main.bundleIdentifier ?? "net.shashankshekhar.vigilant"
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString("subsystem:\(subsystem)", forType: .string)
+        consoleFilterCopied = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+            NSWorkspace.shared.open(
+                URL(fileURLWithPath: "/System/Applications/Utilities/Console.app")
+            )
+            consoleFilterCopied = false
+        }
+    }
+
+    private var logsCopyLabel: String {
+        switch logsCopyState {
+        case .idle: "Copy Logs"
+        case .copying: "Copying\u{2026}"
+        case .copied: "Copied!"
+        }
+    }
+
+    private func copyCurrentSessionLogs() {
+        logsCopyState = .copying
+        Task.detached {
+            do {
+                let store = try OSLogStore(scope: .currentProcessIdentifier)
+                let position = store.position(timeIntervalSinceLatestBoot: 0)
+                let entries = try store.getEntries(at: position)
+                    .compactMap { $0 as? OSLogEntryLog }
+                    .map { "[\($0.date.formatted(.iso8601))] [\($0.category)] \($0.composedMessage)" }
+
+                let text = entries.joined(separator: "\n")
+                await MainActor.run {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(text.isEmpty ? "No logs found for this session." : text, forType: .string)
+                    logsCopyState = .copied
+                }
+            } catch {
+                await MainActor.run {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString("Failed to read logs: \(error.localizedDescription)", forType: .string)
+                    logsCopyState = .copied
+                }
+            }
+            try? await Task.sleep(for: .seconds(2))
+            await MainActor.run {
+                logsCopyState = .idle
+            }
         }
     }
 }

--- a/App/Views/SettingsView.swift
+++ b/App/Views/SettingsView.swift
@@ -18,7 +18,7 @@ struct SettingsView: View {
                 .tabItem { Label("General", systemImage: "gearshape") }
                 .tag(AppState.SettingsTab.general)
 
-            AboutTab()
+            AboutTab(sparkleUpdater: sparkleUpdater)
                 .tabItem { Label("About", systemImage: "info.circle") }
                 .tag(AppState.SettingsTab.about)
         }


### PR DESCRIPTION
## Summary
- Move "Copy Logs" and "Open Console" from the About tab into a new **Diagnostics** section on the General tab, each with a short secondary-text description
- Move "Check for Updates…" from the General tab to the About tab (the auto-check toggle stays in General)

Closes #11

## Test plan
- [x] `xcodebuild build` succeeds
- [x] `swift test` passes in both packages (24 + 18 tests)
- [x] General → Diagnostics: "Copy Logs" copies session logs to clipboard; "Open Console" copies subsystem filter and opens Console
- [x] About → "Check for Updates…" triggers Sparkle update check