### PR TITLE
device flow: retry transient network errors

### DIFF
--- a/Packages/GitHubKit/Sources/GitHubKit/DeviceFlowManager.swift
+++ b/Packages/GitHubKit/Sources/GitHubKit/DeviceFlowManager.swift
@@ -90,8 +90,8 @@ public struct DeviceFlowManager: Sendable {
         request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
         request.httpBody = Self.formEncode(["client_id": clientID])
 
-        let (data, httpResponse) = try await session.data(for: request)
-        logger.debug("requestDeviceCode status=\((httpResponse as? HTTPURLResponse)?.statusCode ?? 0)")
+        let (data, httpResponse) = try await Self.executeWithRetry(request: request, session: session)
+        logger.debug("requestDeviceCode status=\(httpResponse.statusCode)")
 
         // Check for error response from GitHub
         if let errorResponse = try? JSONDecoder().decode(GitHubErrorResponse.self, from: data),
@@ -175,12 +175,52 @@ public struct DeviceFlowManager: Sendable {
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await session.data(for: request)
-        if let httpResponse = response as? HTTPURLResponse,
-           !(200...299).contains(httpResponse.statusCode) {
+        let (data, httpResponse) = try await Self.executeWithRetry(request: request, session: session)
+        if !(200...299).contains(httpResponse.statusCode) {
             throw DeviceFlowError.requestFailed("GitHub API returned HTTP \(httpResponse.statusCode)")
         }
         return try JSONDecoder().decode(GitHubUser.self, from: data)
+    }
+
+    /// Execute a request with exponential backoff retry for transient errors (5xx, network-level).
+    /// Does not retry 4xx responses. Mirrors the pattern in `GitHubAPIClient.executeRequest`.
+    private static func executeWithRetry(
+        request: URLRequest,
+        session: URLSession,
+        maxRetries: Int = 2
+    ) async throws -> (Data, HTTPURLResponse) {
+        for attempt in 0...maxRetries {
+            if attempt > 0 {
+                try await Task.sleep(for: .seconds(pow(2.0, Double(attempt - 1))))
+            }
+
+            let data: Data
+            let httpResponse: HTTPURLResponse
+
+            do {
+                let (d, response) = try await session.data(for: request)
+                guard let r = response as? HTTPURLResponse else {
+                    throw DeviceFlowError.requestFailed("Invalid response from GitHub")
+                }
+                data = d
+                httpResponse = r
+            } catch let error as DeviceFlowError {
+                throw error
+            } catch {
+                // Network-level error (timeout, DNS, connection reset) — retry
+                if attempt < maxRetries { continue }
+                throw error
+            }
+
+            // Server error — retry if attempts remain; 4xx falls through.
+            if (500...599).contains(httpResponse.statusCode) && attempt < maxRetries {
+                continue
+            }
+
+            return (data, httpResponse)
+        }
+
+        throw DeviceFlowError.requestFailed("Exhausted retries")
     }
 
     private struct GitHubErrorResponse: Codable {

--- a/Packages/GitHubKit/Tests/GitHubKitTests/DeviceFlowManagerTests.swift
+++ b/Packages/GitHubKit/Tests/GitHubKitTests/DeviceFlowManagerTests.swift
@@ -214,6 +214,51 @@ struct DeviceFlowManagerTests {
         #expect(response.expiresIn == 28800)
     }
 
+    @Test func requestDeviceCodeRetriesOn5xx() async throws {
+        var callCount = 0
+        MockProtocol.handler = { request in
+            callCount += 1
+            if callCount < 2 {
+                let data = Data()
+                let response = HTTPURLResponse(url: request.url!, statusCode: 503, httpVersion: nil, headerFields: nil)!
+                return (data, response)
+            }
+            let json = """
+            {
+                "device_code": "retry-ok",
+                "user_code": "R-ETRY",
+                "verification_uri": "https://github.com/login/device",
+                "expires_in": 899,
+                "interval": 0
+            }
+            """
+            let data = json.data(using: .utf8)!
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (data, response)
+        }
+
+        let manager = DeviceFlowManager(clientID: "test-client-id")
+        let code = try await manager.requestDeviceCode(session: mockSession())
+        #expect(code.deviceCode == "retry-ok")
+        #expect(callCount == 2)
+    }
+
+    @Test func fetchUserDoesNotRetryOn4xx() async throws {
+        var callCount = 0
+        MockProtocol.handler = { request in
+            callCount += 1
+            let data = Data()
+            let response = HTTPURLResponse(url: request.url!, statusCode: 401, httpVersion: nil, headerFields: nil)!
+            return (data, response)
+        }
+
+        let manager = DeviceFlowManager(clientID: "test-client-id")
+        await #expect(throws: DeviceFlowError.self) {
+            _ = try await manager.fetchUser(token: "bad-token", session: mockSession())
+        }
+        #expect(callCount == 1)
+    }
+
     @Test func refreshTokenThrowsOnError() async throws {
         MockProtocol.handler = { request in
             let json = """


### PR DESCRIPTION
Closes #15

- Reuses exponential backoff pattern from GitHubAPIClient
- Retries requestDeviceCode() and fetchUser() on transient failures
- Skips 4xx and polling-loop responses