### PR TITLE
app: cancel polling on termination

### DIFF
--- a/App/AppState.swift
+++ b/App/AppState.swift
@@ -167,6 +167,11 @@ final class AppState {
         }
     }
 
+    /// Cancel the polling task. Best-effort cleanup for app termination.
+    func stopPolling() async {
+        await poller.stopPolling()
+    }
+
     func refreshNow() async {
         guard networkMonitor.isConnected else {
             logger.info("Skipping refresh — offline")

--- a/App/VigilantApp.swift
+++ b/App/VigilantApp.swift
@@ -53,4 +53,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     @objc func togglePopover() {
         statusBarController.togglePopover()
     }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        // Best-effort cancellation of in-flight polling so pending requests
+        // don't log errors as the process is torn down.
+        let semaphore = DispatchSemaphore(value: 0)
+        Task { @MainActor in
+            await appState.stopPolling()
+            semaphore.signal()
+        }
+        _ = semaphore.wait(timeout: .now() + 0.5)
+    }
 }


### PR DESCRIPTION
Closes #24

- Calls stopPolling() from applicationWillTerminate
- Prevents in-flight request noise during shutdown