### PR TITLE
network monitor: isolate to MainActor

### DIFF
--- a/App/Utilities/NetworkMonitor.swift
+++ b/App/Utilities/NetworkMonitor.swift
@@ -4,26 +4,18 @@ import os
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "NetworkMonitor")
 
-/// @unchecked Sendable is safe: `isConnected` is only mutated via DispatchQueue.main.async,
-/// and all reads happen on @MainActor (AppState, SwiftUI views).
 @Observable
-final class NetworkMonitor: @unchecked Sendable {
+@MainActor
+final class NetworkMonitor {
     private(set) var isConnected = true
     private let monitor = NWPathMonitor()
     private let queue = DispatchQueue(label: "\(Bundle.main.bundleIdentifier!).networkmonitor")
 
     init() {
-        monitor.pathUpdateHandler = { [weak self] path in
+        monitor.pathUpdateHandler = { path in
             let connected = path.status == .satisfied
-            DispatchQueue.main.async {
-                guard let self else { return }
-                let wasConnected = self.isConnected
-                self.isConnected = connected
-                if !wasConnected && connected {
-                    logger.info("Network connectivity restored")
-                } else if wasConnected && !connected {
-                    logger.info("Network connectivity lost")
-                }
+            Task { @MainActor in
+                self.update(isConnected: connected)
             }
         }
         monitor.start(queue: queue)
@@ -31,5 +23,15 @@ final class NetworkMonitor: @unchecked Sendable {
 
     deinit {
         monitor.cancel()
+    }
+
+    private func update(isConnected connected: Bool) {
+        let wasConnected = isConnected
+        isConnected = connected
+        if !wasConnected && connected {
+            logger.info("Network connectivity restored")
+        } else if wasConnected && !connected {
+            logger.info("Network connectivity lost")
+        }
     }
 }


### PR DESCRIPTION
Closes #25

- Annotates NetworkMonitor with @MainActor
- Removes manual DispatchQueue.main.async hop and weak self
- State updates dispatched via Task { @MainActor in ... }