### PR TITLE
status poller: eager 401 refresh and private repo logs

### DIFF
--- a/Packages/CIStatusKit/Sources/CIStatusKit/StatusPoller.swift
+++ b/Packages/CIStatusKit/Sources/CIStatusKit/StatusPoller.swift
@@ -18,6 +18,11 @@ public actor StatusPoller {
     private var clients: [UUID: GitHubAPIClient] = [:]
     private var pollingTask: Task<Void, Never>?
 
+    /// Per-poll, per-account token refresh state so concurrent 401s for the
+    /// same account trigger only one refresh attempt; other in-flight repo
+    /// fetches await the same result.
+    private var refreshTasks: [UUID: Task<Bool, Never>] = [:]
+
     public init(aggregator: StatusAggregator, fetcher: RepoFetcher? = nil) {
         self.aggregator = aggregator
         self.fetcher = fetcher
@@ -68,22 +73,45 @@ public actor StatusPoller {
 
     private typealias FetchResult = (Repository, Account, BuildStatus, FetchIssue)
 
+    /// Deduplicate token refresh attempts for a given account within a single
+    /// poll cycle. The first caller for an account ID kicks off the refresh
+    /// task; subsequent callers await the same task's result.
+    private func refreshToken(for accountID: UUID) async -> Bool {
+        guard let refresher = tokenRefresher else { return false }
+        if let existing = refreshTasks[accountID] {
+            return await existing.value
+        }
+        let task = Task { await refresher(accountID) }
+        refreshTasks[accountID] = task
+        return await task.value
+    }
+
     /// Execute a single poll cycle across all accounts and monitored repos.
     public func pollOnce(
         accounts: [(Account, [Repository])]
     ) async {
-        // Phase 1: Collect results from concurrent fetches
-        let results = await fetchAll(accounts: accounts)
+        // Reset per-poll refresh state so a new poll cycle is free to attempt
+        // a fresh refresh — the previous cycle's cached outcome is no longer
+        // authoritative (e.g. clock skew, a user-initiated re-auth).
+        refreshTasks = [:]
 
-        // Phase 2: Attempt token refresh for auth-failed accounts
+        // Phase 1: Concurrent fetch. The first 401 for an account eagerly
+        // triggers a token refresh; concurrent 401s for the same account
+        // dedup onto the same refresh task, and each 401'd repo retries
+        // once with the refreshed token.
+        let results = await fetchAll(accounts: accounts, allowEagerRefresh: true)
+
+        // Phase 2: Any repos still auth-failed after eager refresh — either
+        // the refresher wasn't configured, or the refresh failed. For each
+        // such account, try a refresh (dedup'd via refreshTasks) and retry.
         let authFailedIDs = Set(results.filter {
             if case .auth = $0.3 { return true }; return false
         }.map { $0.1.id })
         var refreshedIDs: Set<UUID> = []
 
-        if let refresher = tokenRefresher, !authFailedIDs.isEmpty {
+        if tokenRefresher != nil, !authFailedIDs.isEmpty {
             for accountID in authFailedIDs {
-                if await refresher(accountID) {
+                if await refreshToken(for: accountID) {
                     logger.info("Token refreshed for account \(accountID)")
                     refreshedIDs.insert(accountID)
                 } else {
@@ -92,7 +120,7 @@ public actor StatusPoller {
             }
         }
 
-        // Phase 3: Retry repos for successfully refreshed accounts
+        // Phase 3: Retry repos for successfully refreshed accounts.
         var finalResults = results.filter {
             if case .auth = $0.3, refreshedIDs.contains($0.1.id) { return false }
             return true
@@ -100,7 +128,9 @@ public actor StatusPoller {
 
         if !refreshedIDs.isEmpty {
             let retryAccounts = accounts.filter { refreshedIDs.contains($0.0.id) }
-            let retryResults = await fetchAll(accounts: retryAccounts)
+            // Already refreshed — disable eager refresh on this pass so a
+            // still-failing token doesn't loop.
+            let retryResults = await fetchAll(accounts: retryAccounts, allowEagerRefresh: false)
             finalResults.append(contentsOf: retryResults)
         }
 
@@ -135,8 +165,12 @@ public actor StatusPoller {
     }
 
     /// Fetch statuses for all monitored repos across accounts.
+    /// When `allowEagerRefresh` is true, the first 401 seen per account
+    /// kicks off a token refresh and that repo's fetch is retried once
+    /// within the same pass.
     private func fetchAll(
-        accounts: [(Account, [Repository])]
+        accounts: [(Account, [Repository])],
+        allowEagerRefresh: Bool
     ) async -> [FetchResult] {
         await withTaskGroup(
             of: FetchResult?.self
@@ -146,33 +180,11 @@ public actor StatusPoller {
 
                 for repo in monitoredRepos {
                     group.addTask { [self] in
-                        do {
-                            let status: BuildStatus
-                            if let fetcher = self.fetcher {
-                                status = try await fetcher(account, repo)
-                            } else {
-                                status = try await self.fetchStatus(account: account, repo: repo)
-                            }
-                            return (repo, account, status, .none)
-                        } catch {
-                            let apiError = error as? GitHubAPIError
-                            let issue: FetchIssue
-                            if apiError?.isUnauthorized == true {
-                                logger.warning("\(repo.fullName): authentication failed (401)")
-                                issue = .auth
-                            } else if case .rateLimited(let retryAfter) = apiError {
-                                logger.warning("\(repo.fullName): rate limited")
-                                issue = .rateLimited(retryAfter: retryAfter)
-                            } else if apiError?.isNotFound == true {
-                                logger.warning("\(repo.fullName): not found (404) — repo may have been deleted or transferred")
-                                issue = .notFound
-                            } else {
-                                issue = .none
-                            }
-                            return (repo, account, BuildStatus(
-                                status: .unknown, buildURL: nil, updatedAt: .distantPast, source: .combined
-                            ), issue)
-                        }
+                        await self.fetchWithEagerRefresh(
+                            account: account,
+                            repo: repo,
+                            allowEagerRefresh: allowEagerRefresh
+                        )
                     }
                 }
             }
@@ -182,6 +194,59 @@ public actor StatusPoller {
                 if let r = result { collected.append(r) }
             }
             return collected
+        }
+    }
+
+    /// Fetch a single repo's status. If the first attempt is a 401 and
+    /// eager refresh is allowed, trigger (or await) a refresh for the
+    /// account and try once more before giving up.
+    private func fetchWithEagerRefresh(
+        account: Account,
+        repo: Repository,
+        allowEagerRefresh: Bool
+    ) async -> FetchResult {
+        let first = await fetchOnce(account: account, repo: repo)
+        guard case .auth = first.3, allowEagerRefresh, tokenRefresher != nil else {
+            return first
+        }
+
+        // First 401 for this account — try to refresh (dedup'd) and retry.
+        let refreshed = await refreshToken(for: account.id)
+        if refreshed {
+            logger.info("Token refreshed eagerly for account \(account.id)")
+            return await fetchOnce(account: account, repo: repo)
+        }
+        return first
+    }
+
+    /// Single-shot fetch without any retry or refresh logic.
+    private func fetchOnce(account: Account, repo: Repository) async -> FetchResult {
+        do {
+            let status: BuildStatus
+            if let fetcher = self.fetcher {
+                status = try await fetcher(account, repo)
+            } else {
+                status = try await self.fetchStatus(account: account, repo: repo)
+            }
+            return (repo, account, status, .none)
+        } catch {
+            let apiError = error as? GitHubAPIError
+            let issue: FetchIssue
+            if apiError?.isUnauthorized == true {
+                logger.warning("\(repo.fullName, privacy: .private): authentication failed (401)")
+                issue = .auth
+            } else if case .rateLimited(let retryAfter) = apiError {
+                logger.warning("\(repo.fullName, privacy: .private): rate limited")
+                issue = .rateLimited(retryAfter: retryAfter)
+            } else if apiError?.isNotFound == true {
+                logger.warning("\(repo.fullName, privacy: .private): not found (404) — repo may have been deleted or transferred")
+                issue = .notFound
+            } else {
+                issue = .none
+            }
+            return (repo, account, BuildStatus(
+                status: .unknown, buildURL: nil, updatedAt: .distantPast, source: .combined
+            ), issue)
         }
     }
 
@@ -205,7 +270,7 @@ public actor StatusPoller {
             } catch {
                 let apiError = error as? GitHubAPIError
                 if apiError?.isUnauthorized == true || apiError?.isRateLimited == true { throw error }
-                logger.warning("\(repo.fullName): actions fetch failed: \(error)")
+                logger.warning("\(repo.fullName, privacy: .private): actions fetch failed: \(error)")
                 return nil
             }
         }()
@@ -217,7 +282,7 @@ public actor StatusPoller {
             } catch {
                 let apiError = error as? GitHubAPIError
                 if apiError?.isUnauthorized == true || apiError?.isRateLimited == true { throw error }
-                logger.warning("\(repo.fullName): commit status fetch failed: \(error)")
+                logger.warning("\(repo.fullName, privacy: .private): commit status fetch failed: \(error)")
                 return nil
             }
         }()
@@ -226,7 +291,7 @@ public actor StatusPoller {
         let status = try await statusResult
 
         logger.debug("""
-            \(repo.fullName): \
+            \(repo.fullName, privacy: .private): \
             actions=\(run?.conclusion ?? "nil", privacy: .public) \
             path=\(run?.path ?? "none", privacy: .public) \
             commitStatus=\(status?.state ?? "nil", privacy: .public) \
@@ -255,7 +320,7 @@ public actor StatusPoller {
             updatedAt: apiDate
         )
 
-        logger.debug("\(repo.fullName): merged status=\(String(describing: merged.status), privacy: .public) source=\(String(describing: merged.source), privacy: .public)")
+        logger.debug("\(repo.fullName, privacy: .private): merged status=\(String(describing: merged.status), privacy: .public) source=\(String(describing: merged.source), privacy: .public)")
 
         return merged
     }

--- a/Packages/CIStatusKit/Tests/CIStatusKitTests/StatusPollerTests.swift
+++ b/Packages/CIStatusKit/Tests/CIStatusKitTests/StatusPollerTests.swift
@@ -23,3 +23,88 @@ import Foundation
     #expect(fetchedRepos == ["acme/api"]) // only monitored repo
     #expect(aggregator.globalStatus == .success)
 }
+
+// MARK: - Eager refresh helpers
+
+/// Actor-isolated call log so concurrent test fetchers can record attempts safely.
+private actor PollerCallLog {
+    private(set) var calls: [(repo: String, attempt: Int)] = []
+    private var perRepoAttempts: [String: Int] = [:]
+
+    func record(_ repo: String) -> Int {
+        let next = (perRepoAttempts[repo] ?? 0) + 1
+        perRepoAttempts[repo] = next
+        calls.append((repo, next))
+        return next
+    }
+
+    func count(for repo: String) -> Int { perRepoAttempts[repo] ?? 0 }
+}
+
+private actor PollerRefreshCounter {
+    private(set) var count = 0
+    func tick() { count += 1 }
+}
+
+private actor PollerTokenState {
+    private var fresh = false
+    var isFresh: Bool { fresh }
+    func markFresh() { fresh = true }
+}
+
+@MainActor
+@Test func pollerEagerRefreshOn401() async throws {
+    // Given an account with several repos where fetches fail with 401 until
+    // the token is refreshed. The refresher returns true and marks the token
+    // fresh. Expectations:
+    //   - exactly one refresh is triggered for the account (dedup'd across
+    //     the concurrent fetches)
+    //   - every repo ends up with a success status after retry
+    //   - at least one repo is retried within the same poll cycle (the one
+    //     whose initial 401 kicked off the eager refresh)
+    let aggregator = StatusAggregator()
+    let log = PollerCallLog()
+    let refreshes = PollerRefreshCounter()
+    let tokenState = PollerTokenState()
+
+    let fetcher: StatusPoller.RepoFetcher = { _, repo in
+        _ = await log.record(repo.fullName)
+        if await tokenState.isFresh {
+            return BuildStatus(status: .success, buildURL: nil, updatedAt: Date(), source: .actions)
+        } else {
+            throw GitHubAPIError.httpError(statusCode: 401)
+        }
+    }
+
+    let account = Account(name: "Work", username: "work", iconSymbol: "icon-rocket")
+    let repos = (1...5).map { i in
+        Repository(
+            id: i,
+            fullName: "acme/repo-\(i)",
+            defaultBranch: "main",
+            isPrivate: false,
+            isMonitored: true,
+            hasWorkflows: true,
+            accountID: account.id
+        )
+    }
+
+    let poller = StatusPoller(aggregator: aggregator, fetcher: fetcher)
+    await poller.setTokenRefresher { accountID in
+        #expect(accountID == account.id)
+        await refreshes.tick()
+        await tokenState.markFresh()
+        return true
+    }
+
+    await poller.pollOnce(accounts: [(account, repos)])
+
+    #expect(await refreshes.count == 1)
+    #expect(aggregator.globalStatus == .success)
+
+    for repo in repos {
+        #expect(await log.count(for: repo.fullName) >= 1)
+    }
+    let retries = await log.calls.filter { $0.attempt > 1 }
+    #expect(!retries.isEmpty, "at least one repo should have been retried post-refresh")
+}


### PR DESCRIPTION
Closes #16, #23

- Refreshes tokens on first 401 per account (was: after all fetches)
- Retries failed repos for that account in the same poll cycle
- Marks repo.fullName as private in os.log calls