### PR TITLE
cache store: extract testable decoder and add migration tests

### DIFF
--- a/App/AppState.swift
+++ b/App/AppState.swift
@@ -5,81 +5,6 @@ import os
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: "AppState")
 
-// MARK: - Cached Status Entry
-
-private struct CachedRepoStatus: Codable {
-    /// Current schema version for cached status entries. Bump when adding/removing
-    /// fields or changing the encoding of `statusRaw` / `sourceRaw`.
-    static let currentVersion = 1
-
-    /// Missing on pre-versioned entries; treat absence as `currentVersion` for
-    /// backward compat with data written before this field existed.
-    var version: Int?
-    let repoID: Int
-    let statusRaw: String
-    let buildURL: URL?
-    let updatedAt: Date
-    let sourceRaw: String
-    let duration: TimeInterval?
-
-    init(repoID: Int, entry: RepoStatusEntry) {
-        self.version = Self.currentVersion
-        self.repoID = repoID
-        self.statusRaw = Self.encodeStatus(entry.status.status)
-        self.buildURL = entry.status.buildURL
-        self.updatedAt = entry.status.updatedAt
-        self.sourceRaw = Self.encodeSource(entry.status.source)
-        self.duration = entry.status.duration
-    }
-
-    /// Effective version — untagged (pre-v1) entries are treated as v1.
-    var effectiveVersion: Int { version ?? Self.currentVersion }
-
-    func toBuildStatus() -> BuildStatus? {
-        guard let status = Self.decodeStatus(statusRaw),
-              let source = Self.decodeSource(sourceRaw) else { return nil }
-        return BuildStatus(status: status, buildURL: buildURL, updatedAt: updatedAt, source: source, duration: duration)
-    }
-
-    private static func encodeStatus(_ status: BuildStatus.Status) -> String {
-        switch status {
-        case .unknown: "unknown"
-        case .success: "success"
-        case .building: "building"
-        case .pending: "pending"
-        case .failure: "failure"
-        }
-    }
-
-    private static func decodeStatus(_ raw: String) -> BuildStatus.Status? {
-        switch raw {
-        case "unknown": .unknown
-        case "success": .success
-        case "building": .building
-        case "pending": .pending
-        case "failure": .failure
-        default: nil
-        }
-    }
-
-    private static func encodeSource(_ source: BuildStatus.Source) -> String {
-        switch source {
-        case .actions: "actions"
-        case .commitStatus: "commitStatus"
-        case .combined: "combined"
-        }
-    }
-
-    private static func decodeSource(_ raw: String) -> BuildStatus.Source? {
-        switch raw {
-        case "actions": .actions
-        case "commitStatus": .commitStatus
-        case "combined": .combined
-        default: nil
-        }
-    }
-}
-
 @Observable
 @MainActor
 final class AppState {
@@ -523,7 +448,7 @@ final class AppState {
 
     private func saveCachedStatuses() {
         let cached = aggregator.repoStatuses.map { (repoID, entry) in
-            CachedRepoStatus(repoID: repoID, entry: entry)
+            CachedRepoStatus(repoID: repoID, status: entry.status)
         }
         if let data = try? JSONEncoder().encode(cached) {
             UserDefaults.standard.set(data, forKey: "cachedStatuses")
@@ -532,32 +457,14 @@ final class AppState {
 
     private func loadCachedStatuses() {
         let data = UserDefaults.standard.data(forKey: "cachedStatuses")
-        var cached: [CachedRepoStatus] = []
-        if let data {
-            // Decode each entry individually so a single corrupt or future-versioned
-            // entry doesn't nuke the whole cache.
-            if let rawArray = try? JSONSerialization.jsonObject(with: data) as? [Any] {
-                let decoder = JSONDecoder()
-                var dropped = 0
-                for raw in rawArray {
-                    guard let entryData = try? JSONSerialization.data(withJSONObject: raw),
-                          let entry = try? decoder.decode(CachedRepoStatus.self, from: entryData) else {
-                        dropped += 1
-                        continue
-                    }
-                    guard entry.effectiveVersion == CachedRepoStatus.currentVersion else {
-                        dropped += 1
-                        continue
-                    }
-                    cached.append(entry)
-                }
-                if dropped > 0 {
-                    logger.warning("Dropped \(dropped) cached status entries with incompatible version or corrupt data")
-                }
-            } else {
-                logger.warning("cachedStatuses decode failed — first poll will seed baseline without notifying")
-            }
-        } else if !repositories.isEmpty {
+        let result = CachedStatusStore.decode(data)
+        let cached = result.entries
+        if result.blobCorrupt {
+            logger.warning("cachedStatuses decode failed — first poll will seed baseline without notifying")
+        } else if result.droppedCount > 0 {
+            logger.warning("Dropped \(result.droppedCount) cached status entries with incompatible version or corrupt data")
+        }
+        if data == nil && !repositories.isEmpty {
             logger.warning("cachedStatuses missing despite \(self.repositories.count) configured repos — possible container reset; first poll will seed baseline without notifying")
         }
         guard !cached.isEmpty else { return }

--- a/Packages/CIStatusKit/Sources/CIStatusKit/CachedStatusStore.swift
+++ b/Packages/CIStatusKit/Sources/CIStatusKit/CachedStatusStore.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+/// A version-tagged cache entry for a single repository's build status.
+///
+/// Stored as an array of these entries in UserDefaults. Entries are decoded
+/// individually so a single corrupt or future-versioned entry doesn't nuke
+/// the whole cache. The `version` field is optional for backward compatibility
+/// with pre-v1 entries that predate the field — those are treated as v1.
+public struct CachedRepoStatus: Codable, Sendable, Equatable {
+    /// Current schema version for cached status entries. Bump when adding/removing
+    /// fields or changing the encoding of `statusRaw` / `sourceRaw`.
+    public static let currentVersion = 1
+
+    /// Missing on pre-versioned entries; treat absence as `currentVersion` for
+    /// backward compat with data written before this field existed.
+    public var version: Int?
+    public let repoID: Int
+    public let statusRaw: String
+    public let buildURL: URL?
+    public let updatedAt: Date
+    public let sourceRaw: String
+    public let duration: TimeInterval?
+
+    public init(
+        version: Int? = currentVersion,
+        repoID: Int,
+        statusRaw: String,
+        buildURL: URL?,
+        updatedAt: Date,
+        sourceRaw: String,
+        duration: TimeInterval?
+    ) {
+        self.version = version
+        self.repoID = repoID
+        self.statusRaw = statusRaw
+        self.buildURL = buildURL
+        self.updatedAt = updatedAt
+        self.sourceRaw = sourceRaw
+        self.duration = duration
+    }
+
+    public init(repoID: Int, status: BuildStatus) {
+        self.version = Self.currentVersion
+        self.repoID = repoID
+        self.statusRaw = Self.encodeStatus(status.status)
+        self.buildURL = status.buildURL
+        self.updatedAt = status.updatedAt
+        self.sourceRaw = Self.encodeSource(status.source)
+        self.duration = status.duration
+    }
+
+    /// Effective version — untagged (pre-v1) entries are treated as v1.
+    public var effectiveVersion: Int { version ?? Self.currentVersion }
+
+    public func toBuildStatus() -> BuildStatus? {
+        guard let status = Self.decodeStatus(statusRaw),
+              let source = Self.decodeSource(sourceRaw) else { return nil }
+        return BuildStatus(status: status, buildURL: buildURL, updatedAt: updatedAt, source: source, duration: duration)
+    }
+
+    public static func encodeStatus(_ status: BuildStatus.Status) -> String {
+        switch status {
+        case .unknown: "unknown"
+        case .success: "success"
+        case .building: "building"
+        case .pending: "pending"
+        case .failure: "failure"
+        }
+    }
+
+    public static func decodeStatus(_ raw: String) -> BuildStatus.Status? {
+        switch raw {
+        case "unknown": .unknown
+        case "success": .success
+        case "building": .building
+        case "pending": .pending
+        case "failure": .failure
+        default: nil
+        }
+    }
+
+    public static func encodeSource(_ source: BuildStatus.Source) -> String {
+        switch source {
+        case .actions: "actions"
+        case .commitStatus: "commitStatus"
+        case .combined: "combined"
+        }
+    }
+
+    public static func decodeSource(_ raw: String) -> BuildStatus.Source? {
+        switch raw {
+        case "actions": .actions
+        case "commitStatus": .commitStatus
+        case "combined": .combined
+        default: nil
+        }
+    }
+}
+
+/// Outcome of decoding a cached-statuses blob.
+public struct CachedStatusDecodeResult: Sendable, Equatable {
+    /// Entries that decoded cleanly and passed version checks.
+    public let entries: [CachedRepoStatus]
+    /// Number of entries that failed to decode or had an unsupported version.
+    public let droppedCount: Int
+    /// True if the top-level blob itself was corrupt (not a JSON array of objects).
+    public let blobCorrupt: Bool
+
+    public init(entries: [CachedRepoStatus], droppedCount: Int, blobCorrupt: Bool) {
+        self.entries = entries
+        self.droppedCount = droppedCount
+        self.blobCorrupt = blobCorrupt
+    }
+}
+
+public enum CachedStatusStore {
+    /// Decode a `cachedStatuses` UserDefaults blob into individual entries.
+    ///
+    /// - Corrupt top-level blob → `blobCorrupt = true`, empty entries.
+    /// - Individual entries that fail to decode → dropped, counted in `droppedCount`.
+    /// - Entries whose `effectiveVersion` is not `CachedRepoStatus.currentVersion`
+    ///   (including future versions) → dropped, counted in `droppedCount`.
+    /// - Missing `version` field is treated as `currentVersion` (backward compat).
+    public static func decode(_ data: Data?) -> CachedStatusDecodeResult {
+        guard let data else {
+            return CachedStatusDecodeResult(entries: [], droppedCount: 0, blobCorrupt: false)
+        }
+        guard let rawArray = try? JSONSerialization.jsonObject(with: data) as? [Any] else {
+            return CachedStatusDecodeResult(entries: [], droppedCount: 0, blobCorrupt: true)
+        }
+        let decoder = JSONDecoder()
+        var entries: [CachedRepoStatus] = []
+        var dropped = 0
+        for raw in rawArray {
+            guard let entryData = try? JSONSerialization.data(withJSONObject: raw),
+                  let entry = try? decoder.decode(CachedRepoStatus.self, from: entryData) else {
+                dropped += 1
+                continue
+            }
+            guard entry.effectiveVersion == CachedRepoStatus.currentVersion else {
+                dropped += 1
+                continue
+            }
+            entries.append(entry)
+        }
+        return CachedStatusDecodeResult(entries: entries, droppedCount: dropped, blobCorrupt: false)
+    }
+}

--- a/Packages/CIStatusKit/Tests/CIStatusKitTests/CachedStatusStoreTests.swift
+++ b/Packages/CIStatusKit/Tests/CIStatusKitTests/CachedStatusStoreTests.swift
@@ -1,0 +1,196 @@
+import Testing
+import Foundation
+@testable import CIStatusKit
+
+// MARK: - Helpers
+
+/// Build a JSON-serialized array of entry dictionaries for UserDefaults-style storage.
+private func makeBlob(_ entries: [[String: Any]]) -> Data {
+    try! JSONSerialization.data(withJSONObject: entries)
+}
+
+/// A well-formed v1 entry dictionary.
+private func goodEntry(
+    repoID: Int = 1,
+    status: String = "success",
+    source: String = "actions",
+    version: Int? = CachedRepoStatus.currentVersion
+) -> [String: Any] {
+    var dict: [String: Any] = [
+        "repoID": repoID,
+        "statusRaw": status,
+        "buildURL": "https://example.com/build/\(repoID)",
+        "updatedAt": 725846400.0, // some stable Date timeInterval
+        "sourceRaw": source
+    ]
+    if let version {
+        dict["version"] = version
+    }
+    return dict
+}
+
+// MARK: - Tests
+
+@Suite struct CachedStatusStoreTests {
+
+    @Test func nilDataReturnsEmpty() {
+        let result = CachedStatusStore.decode(nil)
+        #expect(result.entries.isEmpty)
+        #expect(result.droppedCount == 0)
+        #expect(result.blobCorrupt == false)
+    }
+
+    @Test func corruptJSONIsIgnoredAndDoesNotCrash() {
+        let garbage = Data("this is not JSON at all {{{".utf8)
+        let result = CachedStatusStore.decode(garbage)
+        #expect(result.entries.isEmpty)
+        #expect(result.blobCorrupt == true)
+    }
+
+    @Test func topLevelObjectInsteadOfArrayMarkedCorrupt() {
+        // Valid JSON, but not an array of entries — must be treated as corrupt.
+        let notAnArray = try! JSONSerialization.data(withJSONObject: ["foo": "bar"])
+        let result = CachedStatusStore.decode(notAnArray)
+        #expect(result.entries.isEmpty)
+        #expect(result.blobCorrupt == true)
+    }
+
+    @Test func emptyArrayYieldsEmptyResult() {
+        let blob = makeBlob([])
+        let result = CachedStatusStore.decode(blob)
+        #expect(result.entries.isEmpty)
+        #expect(result.droppedCount == 0)
+        #expect(result.blobCorrupt == false)
+    }
+
+    @Test func preV1EntryMissingVersionIsAcceptedAsV1() {
+        // Entry without a `version` field (legacy data written before the field existed).
+        let blob = makeBlob([goodEntry(repoID: 42, version: nil)])
+        let result = CachedStatusStore.decode(blob)
+
+        #expect(result.blobCorrupt == false)
+        #expect(result.droppedCount == 0)
+        #expect(result.entries.count == 1)
+        let entry = result.entries[0]
+        #expect(entry.repoID == 42)
+        #expect(entry.version == nil)
+        #expect(entry.effectiveVersion == CachedRepoStatus.currentVersion)
+
+        // And it must decode back into a usable BuildStatus.
+        let restored = entry.toBuildStatus()
+        #expect(restored != nil)
+        #expect(restored?.status == .success)
+    }
+
+    @Test func futureVersionIsDropped() {
+        let futureVersion = CachedRepoStatus.currentVersion + 99
+        let blob = makeBlob([goodEntry(repoID: 1, version: futureVersion)])
+        let result = CachedStatusStore.decode(blob)
+
+        #expect(result.blobCorrupt == false)
+        #expect(result.entries.isEmpty)
+        #expect(result.droppedCount == 1)
+    }
+
+    @Test func mixOfGoodAndBadEntriesKeepsGoodDropsBad() {
+        let blob = makeBlob([
+            // good — explicit v1
+            goodEntry(repoID: 1, status: "failure", source: "actions"),
+            // good — pre-v1 (missing version)
+            goodEntry(repoID: 2, status: "success", source: "commitStatus", version: nil),
+            // bad — future version
+            goodEntry(repoID: 3, version: 9999),
+            // bad — missing required field (statusRaw)
+            [
+                "version": CachedRepoStatus.currentVersion,
+                "repoID": 4,
+                // "statusRaw" intentionally omitted
+                "buildURL": "https://example.com/b/4",
+                "updatedAt": 725846400.0,
+                "sourceRaw": "actions"
+            ] as [String: Any],
+            // bad — wrong type for a required field
+            [
+                "version": CachedRepoStatus.currentVersion,
+                "repoID": "not-an-int",
+                "statusRaw": "success",
+                "buildURL": "https://example.com/b/5",
+                "updatedAt": 725846400.0,
+                "sourceRaw": "actions"
+            ] as [String: Any],
+            // good — another explicit v1
+            goodEntry(repoID: 6, status: "building", source: "combined")
+        ])
+
+        let result = CachedStatusStore.decode(blob)
+
+        #expect(result.blobCorrupt == false)
+        #expect(result.entries.count == 3)
+        #expect(result.droppedCount == 3)
+
+        let keptIDs = Set(result.entries.map(\.repoID))
+        #expect(keptIDs == [1, 2, 6])
+
+        // The pre-v1 entry should still round-trip into a BuildStatus.
+        let preV1 = result.entries.first { $0.repoID == 2 }
+        #expect(preV1?.toBuildStatus()?.status == .success)
+        #expect(preV1?.toBuildStatus()?.source == .commitStatus)
+    }
+
+    @Test func missingRequiredFieldDropsEntry() {
+        // Missing `updatedAt` — JSONDecoder will reject this as a keyNotFound error.
+        let badEntry: [String: Any] = [
+            "version": CachedRepoStatus.currentVersion,
+            "repoID": 1,
+            "statusRaw": "success",
+            "buildURL": "https://example.com/b/1",
+            "sourceRaw": "actions"
+        ]
+        let result = CachedStatusStore.decode(makeBlob([badEntry]))
+        #expect(result.entries.isEmpty)
+        #expect(result.droppedCount == 1)
+        #expect(result.blobCorrupt == false)
+    }
+
+    @Test func unknownStatusRawDecodedButToBuildStatusReturnsNil() {
+        // The raw entry decodes (the struct just stores a string), but
+        // converting to BuildStatus yields nil when the enum string is unknown.
+        let blob = makeBlob([goodEntry(repoID: 1, status: "bogus-status")])
+        let result = CachedStatusStore.decode(blob)
+        #expect(result.entries.count == 1)
+        #expect(result.entries[0].toBuildStatus() == nil)
+    }
+
+    @Test func roundTripEncodeDecodePreservesFields() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let original = BuildStatus(
+            status: .failure,
+            buildURL: URL(string: "https://example.com/run/123")!,
+            updatedAt: now,
+            source: .actions,
+            duration: 42.5
+        )
+        let entry = CachedRepoStatus(repoID: 99, status: original)
+        let encoded = try! JSONEncoder().encode([entry])
+
+        let result = CachedStatusStore.decode(encoded)
+        #expect(result.entries.count == 1)
+        #expect(result.droppedCount == 0)
+
+        let restored = result.entries[0].toBuildStatus()
+        #expect(restored?.status == .failure)
+        #expect(restored?.buildURL?.absoluteString == "https://example.com/run/123")
+        #expect(restored?.source == .actions)
+        #expect(restored?.duration == 42.5)
+        // Date equality through JSON round-trip with the default encoding strategy
+        // (seconds since reference) — both sides use the same strategy.
+        #expect(restored?.updatedAt.timeIntervalSince1970 == now.timeIntervalSince1970)
+    }
+
+    @Test func entryConstructorTagsCurrentVersion() {
+        let s = BuildStatus(status: .success, buildURL: nil, updatedAt: Date(), source: .actions, duration: nil)
+        let entry = CachedRepoStatus(repoID: 1, status: s)
+        #expect(entry.version == CachedRepoStatus.currentVersion)
+        #expect(entry.effectiveVersion == CachedRepoStatus.currentVersion)
+    }
+}


### PR DESCRIPTION
Closes #27

Stacks on #34 (versioned CachedRepoStatus schema).

- Extracts CachedStatusStore.decode from AppState into CIStatusKit for testability
- AppState.loadCachedStatuses now calls into the extracted store (same behaviour)
- Adds 11 tests: corrupt JSON, pre-v1 entries, unknown versions, mixed good/bad, missing fields, unknown enum strings, round-trip, nil/empty input