### PR TITLE
repos: detect and prune missing repos after repeated 404s

### DIFF
--- a/App/AppState.swift
+++ b/App/AppState.swift
@@ -92,7 +92,18 @@ final class AppState {
 
     // MARK: - Data Schema Versioning
 
-    private static let currentDataSchemaVersion = 1
+    private static let currentDataSchemaVersion = 2
+
+    // MARK: - Missing Repo Tracking
+
+    /// Number of consecutive 404 poll cycles required before flipping a
+    /// repo to `isMissing = true`. Guards against transient GitHub blips
+    /// (e.g. brief 404 on a renamed-and-redirected URL).
+    private static let missingThreshold = 3
+
+    /// In-memory per-repo consecutive-404 counter. Not persisted — on launch
+    /// we trust only the `isMissing` flag already stored on each Repository.
+    private var notFoundStreaks: [Int: Int] = [:]
 
     // Persisted
     var accounts: [Account] = [] {
@@ -191,7 +202,8 @@ final class AppState {
         let accountRepos = accounts.map { acct in
             (acct, repositories.filter { $0.accountID == acct.id })
         }
-        await poller.pollOnce(accounts: accountRepos)
+        let result = await poller.pollOnce(accounts: accountRepos)
+        applyPollResult(result)
         checkForNewFailures()
         saveCachedStatuses()
 
@@ -336,7 +348,44 @@ final class AppState {
             await poller.setTokenRefresher { [weak self] accountID in
                 await self?.refreshToken(for: accountID) ?? false
             }
+            await poller.setPollObserver { [weak self] result in
+                await self?.applyPollResult(result)
+            }
         }
+    }
+
+    /// Update the in-memory 404 streak counter and flip repos to `isMissing`
+    /// once the threshold is reached. Called after every poll cycle.
+    func applyPollResult(_ result: PollResult) {
+        // Reset counters for repos that just fetched successfully.
+        for repoID in result.successfulRepoIDs {
+            notFoundStreaks.removeValue(forKey: repoID)
+            if let idx = repositories.firstIndex(where: { $0.id == repoID }),
+               repositories[idx].isMissing {
+                repositories[idx].isMissing = false
+            }
+        }
+
+        // Increment the streak for repos that 404'd this cycle; flip to
+        // `isMissing` when we hit the threshold.
+        for repoID in result.notFoundRepoIDs {
+            let next = (notFoundStreaks[repoID] ?? 0) + 1
+            notFoundStreaks[repoID] = next
+            if next >= Self.missingThreshold,
+               let idx = repositories.firstIndex(where: { $0.id == repoID }),
+               !repositories[idx].isMissing {
+                repositories[idx].isMissing = true
+                logger.warning("Repo \(self.repositories[idx].fullName) marked as missing after \(next) consecutive 404s")
+            }
+        }
+    }
+
+    /// Remove a repo that's been confirmed missing. Clears its cached state
+    /// so lingering notifications don't fire.
+    func removeMissingRepo(_ repo: Repository) {
+        repositories.removeAll { $0.id == repo.id }
+        notFoundStreaks.removeValue(forKey: repo.id)
+        previousStatuses.removeValue(forKey: repo.id)
     }
 
     /// Attempt to refresh an expired access token using the stored refresh token.
@@ -614,6 +663,11 @@ final class AppState {
                 // existing UserDefaults keys (accounts, repositories, pollInterval) are
                 // already in the correct format.
                 logger.info("Migrating data schema from version 0 to 1")
+            case 1:
+                // Version 1 → 2: Added `isMissing` to Repository. The custom Codable
+                // decoder defaults absent values to false, so no data transformation
+                // is needed here — just bump the marker.
+                logger.info("Migrating data schema from version 1 to 2")
             default:
                 logger.warning("Unknown data schema version \(version) — skipping migration step")
             }

--- a/App/StatusBar/PopoverView.swift
+++ b/App/StatusBar/PopoverView.swift
@@ -74,16 +74,21 @@ struct PopoverView: View {
                 }
 
                 // Repo list
+                let missingRepoIDs: Set<Int> = Set(appState.repositories.filter(\.isMissing).map(\.id))
                 ScrollView {
                     LazyVStack(alignment: .leading, spacing: 0) {
                         ForEach(aggregator.sortedAccounts(), id: \.id) { account in
                             let entries = aggregator.sortedEntries(for: account.id)
-                                .filter { $0.status.status != .unknown || $0.repo.hasWorkflows || aggregator.notFoundRepoIDs.contains($0.repo.id) }
+                                .filter { $0.status.status != .unknown || $0.repo.hasWorkflows || aggregator.notFoundRepoIDs.contains($0.repo.id) || missingRepoIDs.contains($0.repo.id) }
                             if !entries.isEmpty {
                                 AccountSectionView(
                                     account: account,
                                     entries: entries,
-                                    notFoundRepoIDs: aggregator.notFoundRepoIDs
+                                    notFoundRepoIDs: aggregator.notFoundRepoIDs,
+                                    missingRepoIDs: missingRepoIDs,
+                                    onRemoveMissing: { repo in
+                                        appState.removeMissingRepo(repo)
+                                    }
                                 )
                             }
                         }

--- a/App/Views/AccountSectionView.swift
+++ b/App/Views/AccountSectionView.swift
@@ -6,14 +6,21 @@ struct AccountSectionView: View {
     let account: Account
     let entries: [RepoStatusEntry]
     var notFoundRepoIDs: Set<Int> = []
+    var missingRepoIDs: Set<Int> = []
+    var onRemoveMissing: ((Repository) -> Void)? = nil
 
     var body: some View {
         Section {
             ForEach(entries, id: \.repo.id) { entry in
+                let isMissing = missingRepoIDs.contains(entry.repo.id)
                 RepoRowView(
                     entry: entry,
-                    isNotFound: notFoundRepoIDs.contains(entry.repo.id),
-                    hideOwnerPrefix: account.hideOwnerPrefix
+                    isNotFound: notFoundRepoIDs.contains(entry.repo.id) && !isMissing,
+                    isMissing: isMissing,
+                    hideOwnerPrefix: account.hideOwnerPrefix,
+                    onRemove: isMissing
+                        ? { onRemoveMissing?(entry.repo) }
+                        : nil
                 )
             }
         } header: {

--- a/App/Views/RepoRowView.swift
+++ b/App/Views/RepoRowView.swift
@@ -5,7 +5,9 @@ import GitHubKit
 struct RepoRowView: View {
     let entry: RepoStatusEntry
     var isNotFound: Bool = false
+    var isMissing: Bool = false
     var hideOwnerPrefix: Bool = false
+    var onRemove: (() -> Void)? = nil
     @State private var isSpinning = false
 
     private var repoDisplayName: String {
@@ -15,9 +17,16 @@ struct RepoRowView: View {
         return entry.repo.fullName
     }
 
+    private var isDimmed: Bool { isNotFound || isMissing }
+
     var body: some View {
         HStack(spacing: 12) {
-            if entry.status.status == .building {
+            if isMissing {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .font(.system(size: 10))
+                    .foregroundStyle(.orange)
+                    .frame(width: 8, height: 8)
+            } else if entry.status.status == .building {
                 buildingIndicator
             } else {
                 Circle()
@@ -28,9 +37,13 @@ struct RepoRowView: View {
             VStack(alignment: .leading, spacing: 2) {
                 Text(repoDisplayName)
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(isNotFound ? .secondary : .primary)
+                    .foregroundStyle(isDimmed ? .secondary : .primary)
 
-                if isNotFound {
+                if isMissing {
+                    Text("Repository missing — deleted, transferred, or renamed")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.orange)
+                } else if isNotFound {
                     Text("Repository not found — may have been deleted or transferred")
                         .font(.system(size: 11))
                         .foregroundStyle(.orange)
@@ -43,16 +56,25 @@ struct RepoRowView: View {
 
             Spacer()
 
-            Image("icon-arrow-right")
-                .resizable()
-                .frame(width: 12, height: 12)
-                .foregroundStyle(.quaternary)
+            if isMissing, let onRemove {
+                Button("Remove", action: onRemove)
+                    .buttonStyle(.plain)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(.blue)
+                    .accessibilityHint(String(localized: "Removes this repository from Vigil-ant"))
+            } else {
+                Image("icon-arrow-right")
+                    .resizable()
+                    .frame(width: 12, height: 12)
+                    .foregroundStyle(.quaternary)
+            }
         }
         .padding(.vertical, 6)
         .padding(.horizontal, 16)
+        .opacity(isDimmed ? 0.75 : 1.0)
         .contentShape(Rectangle())
         .overlay(alignment: .leading) {
-            if entry.status.status == .failure {
+            if entry.status.status == .failure && !isMissing {
                 Rectangle()
                     .fill(.red)
                     .frame(width: 3)
@@ -62,6 +84,7 @@ struct RepoRowView: View {
         .accessibilityLabel("\(repoDisplayName): \(accessibilityStatusLabel)")
         .accessibilityHint(entry.status.buildURL != nil ? String(localized: "Opens build in browser") : "")
         .onTapGesture {
+            if isMissing { return }
             if let url = entry.status.buildURL {
                 NSWorkspace.shared.open(url)
             }
@@ -89,7 +112,8 @@ struct RepoRowView: View {
     }
 
     private var accessibilityStatusLabel: String {
-        switch entry.status.status {
+        if isMissing { return String(localized: "missing, repository deleted or transferred") }
+        return switch entry.status.status {
         case .success: String(localized: "passing")
         case .failure: String(localized: "failing")
         case .building: String(localized: "building")

--- a/Packages/CIStatusKit/Sources/CIStatusKit/StatusPoller.swift
+++ b/Packages/CIStatusKit/Sources/CIStatusKit/StatusPoller.swift
@@ -4,6 +4,23 @@ import os
 
 private let logger = Logger(subsystem: Bundle.main.bundleIdentifier ?? "net.shashankshekhar.vigilant", category: "StatusPoller")
 
+/// Outcome summary from a single poll cycle, returned to callers that need
+/// to react to per-repo fetch results (e.g. tracking repeated 404s for
+/// prune detection).
+public struct PollResult: Sendable {
+    /// Repos whose fetch returned 404 this cycle. Not retried after token
+    /// refresh — a 404 means the repo is gone, not an auth issue.
+    public let notFoundRepoIDs: Set<Int>
+    /// Repos whose fetch succeeded this cycle (no 401, 404, or rate-limit
+    /// issue). Used by the caller to reset any per-repo failure counters.
+    public let successfulRepoIDs: Set<Int>
+
+    public init(notFoundRepoIDs: Set<Int>, successfulRepoIDs: Set<Int>) {
+        self.notFoundRepoIDs = notFoundRepoIDs
+        self.successfulRepoIDs = successfulRepoIDs
+    }
+}
+
 public actor StatusPoller {
     /// Simplified fetcher for testing — takes account and repo, returns a status.
     /// The real implementation uses the internal clients dictionary.
@@ -12,9 +29,15 @@ public actor StatusPoller {
     /// Called when a 401 is detected. Returns true if the token was refreshed successfully.
     public typealias TokenRefresher = @Sendable (UUID) async -> Bool
 
+    /// Called after each poll cycle completes with a summary of which repos
+    /// 404'd vs succeeded. Used by AppState to track repeated 404s so it can
+    /// mark a repo as missing (deleted/transferred) after several cycles.
+    public typealias PollObserver = @Sendable (PollResult) async -> Void
+
     private let aggregator: StatusAggregator
     private let fetcher: RepoFetcher?
     private var tokenRefresher: TokenRefresher?
+    private var pollObserver: PollObserver?
     private var clients: [UUID: GitHubAPIClient] = [:]
     private var pollingTask: Task<Void, Never>?
 
@@ -30,6 +53,10 @@ public actor StatusPoller {
 
     public func setTokenRefresher(_ refresher: @escaping TokenRefresher) {
         tokenRefresher = refresher
+    }
+
+    public func setPollObserver(_ observer: @escaping PollObserver) {
+        pollObserver = observer
     }
 
     public func setClient(_ client: GitHubAPIClient, for accountID: UUID) {
@@ -53,7 +80,7 @@ public actor StatusPoller {
         pollingTask = Task { [weak self] in
             while !Task.isCancelled {
                 guard let self else { return }
-                await self.pollOnce(accounts: await accounts())
+                _ = await self.pollOnce(accounts: await accounts())
                 try? await Task.sleep(for: .seconds(intervalSeconds))
             }
         }
@@ -87,9 +114,12 @@ public actor StatusPoller {
     }
 
     /// Execute a single poll cycle across all accounts and monitored repos.
+    /// Returns a summary of per-repo outcomes (404'd vs succeeded) so callers
+    /// can track repeated failures (e.g. to prune deleted repos).
+    @discardableResult
     public func pollOnce(
         accounts: [(Account, [Repository])]
-    ) async {
+    ) async -> PollResult {
         // Reset per-poll refresh state so a new poll cycle is free to attempt
         // a fresh refresh — the previous cycle's cached outcome is no longer
         // authoritative (e.g. clock skew, a user-initiated re-auth).
@@ -134,12 +164,13 @@ public actor StatusPoller {
             finalResults.append(contentsOf: retryResults)
         }
 
-        // Phase 4: Update aggregator on MainActor
-        await MainActor.run {
+        // Phase 4: Update aggregator on MainActor and build PollResult.
+        let pollResult: PollResult = await MainActor.run {
             var authFailed: Set<UUID> = []
             var rateLimited: Set<UUID> = []
             var latestResetDate: Date?
             var notFound: Set<Int> = []
+            var succeeded: Set<Int> = []
             for (repo, account, status, issue) in finalResults {
                 aggregator.update(repo: repo, account: account, status: status)
                 switch issue {
@@ -154,14 +185,20 @@ public actor StatusPoller {
                         }
                     }
                 case .notFound: notFound.insert(repo.id)
-                case .none: break
+                case .none: succeeded.insert(repo.id)
                 }
             }
             aggregator.setAuthFailures(authFailed)
             aggregator.setRateLimits(rateLimited)
             aggregator.setRateLimitResetDate(rateLimited.isEmpty ? nil : latestResetDate)
             aggregator.setNotFoundRepos(notFound)
+            return PollResult(notFoundRepoIDs: notFound, successfulRepoIDs: succeeded)
         }
+
+        if let observer = pollObserver {
+            await observer(pollResult)
+        }
+        return pollResult
     }
 
     /// Fetch statuses for all monitored repos across accounts.
@@ -269,7 +306,7 @@ public actor StatusPoller {
                 )
             } catch {
                 let apiError = error as? GitHubAPIError
-                if apiError?.isUnauthorized == true || apiError?.isRateLimited == true { throw error }
+                if apiError?.isUnauthorized == true || apiError?.isRateLimited == true || apiError?.isNotFound == true { throw error }
                 logger.warning("\(repo.fullName, privacy: .private): actions fetch failed: \(error)")
                 return nil
             }
@@ -281,7 +318,7 @@ public actor StatusPoller {
                 )
             } catch {
                 let apiError = error as? GitHubAPIError
-                if apiError?.isUnauthorized == true || apiError?.isRateLimited == true { throw error }
+                if apiError?.isUnauthorized == true || apiError?.isRateLimited == true || apiError?.isNotFound == true { throw error }
                 logger.warning("\(repo.fullName, privacy: .private): commit status fetch failed: \(error)")
                 return nil
             }

--- a/Packages/CIStatusKit/Tests/CIStatusKitTests/StatusPollerTests.swift
+++ b/Packages/CIStatusKit/Tests/CIStatusKitTests/StatusPollerTests.swift
@@ -108,3 +108,134 @@ private actor PollerTokenState {
     let retries = await log.calls.filter { $0.attempt > 1 }
     #expect(!retries.isEmpty, "at least one repo should have been retried post-refresh")
 }
+
+// MARK: - 404 handling (deleted / transferred repos)
+
+/// A 404 from a repo fetch should be reported in `PollResult.notFoundRepoIDs`
+/// so AppState can track repeated 404s and flip the repo to `isMissing`.
+/// Successful fetches should land in `successfulRepoIDs` so AppState can
+/// reset streak counters.
+@MainActor
+@Test func pollerReportsNotFoundAndSuccessInPollResult() async throws {
+    let aggregator = StatusAggregator()
+    let account = Account(name: "Work", username: "work", iconSymbol: "icon-rocket")
+    let liveRepo = Repository(id: 1, fullName: "acme/alive", defaultBranch: "main", isPrivate: false, isMonitored: true, hasWorkflows: true, accountID: account.id)
+    let deletedRepo = Repository(id: 2, fullName: "acme/gone", defaultBranch: "main", isPrivate: false, isMonitored: true, hasWorkflows: true, accountID: account.id)
+
+    let fetcher: StatusPoller.RepoFetcher = { _, repo in
+        if repo.id == deletedRepo.id {
+            throw GitHubAPIError.httpError(statusCode: 404)
+        }
+        return BuildStatus(status: .success, buildURL: nil, updatedAt: Date(), source: .actions)
+    }
+
+    let poller = StatusPoller(aggregator: aggregator, fetcher: fetcher)
+    let result = await poller.pollOnce(accounts: [(account, [liveRepo, deletedRepo])])
+
+    #expect(result.notFoundRepoIDs == [deletedRepo.id])
+    #expect(result.successfulRepoIDs == [liveRepo.id])
+    #expect(aggregator.notFoundRepoIDs == [deletedRepo.id])
+}
+
+/// A 404 must NOT trigger a token refresh — 404 means the repo is gone,
+/// not that the token is bad. Only 401 should route through the refresher.
+@MainActor
+@Test func pollerDoesNotRefreshTokenOn404() async throws {
+    let aggregator = StatusAggregator()
+    let refreshes = PollerRefreshCounter()
+
+    let fetcher: StatusPoller.RepoFetcher = { _, _ in
+        throw GitHubAPIError.httpError(statusCode: 404)
+    }
+
+    let account = Account(name: "Work", username: "work", iconSymbol: "icon-rocket")
+    let repo = Repository(id: 42, fullName: "acme/gone", defaultBranch: "main", isPrivate: false, isMonitored: true, hasWorkflows: true, accountID: account.id)
+
+    let poller = StatusPoller(aggregator: aggregator, fetcher: fetcher)
+    await poller.setTokenRefresher { _ in
+        await refreshes.tick()
+        return true
+    }
+
+    _ = await poller.pollOnce(accounts: [(account, [repo])])
+
+    #expect(await refreshes.count == 0, "404s must not trigger token refresh")
+    #expect(aggregator.notFoundRepoIDs == [repo.id])
+}
+
+/// Simulates the AppState-side counter logic against real `PollResult`
+/// values over multiple poll cycles: repeated 404s should accumulate past
+/// the threshold, while any successful fetch in between resets the streak.
+/// Keeps the test in the poller layer by inlining the counter logic.
+@MainActor
+@Test func consecutive404sAccumulateAndResetOnSuccess() async throws {
+    let aggregator = StatusAggregator()
+    let account = Account(name: "Work", username: "work", iconSymbol: "icon-rocket")
+    let repo = Repository(id: 7, fullName: "acme/flaky", defaultBranch: "main", isPrivate: false, isMonitored: true, hasWorkflows: true, accountID: account.id)
+
+    // Deterministic sequence of per-cycle outcomes: three 404s → then a success.
+    let outcomes = ActorBool(values: [false, false, false, true])
+    let fetcher: StatusPoller.RepoFetcher = { _, _ in
+        let succeed = await outcomes.next()
+        if succeed {
+            return BuildStatus(status: .success, buildURL: nil, updatedAt: Date(), source: .actions)
+        }
+        throw GitHubAPIError.httpError(statusCode: 404)
+    }
+
+    let poller = StatusPoller(aggregator: aggregator, fetcher: fetcher)
+
+    // Mirror AppState's counter logic locally; threshold of 3.
+    var streaks: [Int: Int] = [:]
+    var isMissing = false
+    let threshold = 3
+
+    func applyResult(_ r: PollResult) {
+        for id in r.successfulRepoIDs {
+            streaks.removeValue(forKey: id)
+            if id == repo.id { isMissing = false }
+        }
+        for id in r.notFoundRepoIDs {
+            let n = (streaks[id] ?? 0) + 1
+            streaks[id] = n
+            if n >= threshold, id == repo.id { isMissing = true }
+        }
+    }
+
+    // Cycle 1: 404 — counter = 1, not yet missing.
+    applyResult(await poller.pollOnce(accounts: [(account, [repo])]))
+    #expect(streaks[repo.id] == 1)
+    #expect(!isMissing)
+
+    // Cycle 2: 404 — counter = 2, not yet missing.
+    applyResult(await poller.pollOnce(accounts: [(account, [repo])]))
+    #expect(streaks[repo.id] == 2)
+    #expect(!isMissing)
+
+    // Cycle 3: 404 — counter = 3, flips to missing.
+    applyResult(await poller.pollOnce(accounts: [(account, [repo])]))
+    #expect(streaks[repo.id] == 3)
+    #expect(isMissing)
+
+    // Cycle 4: success — counter resets and missing clears.
+    applyResult(await poller.pollOnce(accounts: [(account, [repo])]))
+    #expect(streaks[repo.id] == nil)
+    #expect(!isMissing)
+}
+
+/// Drains a scripted sequence of boolean outcomes; re-uses the last value
+/// once the script runs out so long tests don't need to pad.
+private actor ActorBool {
+    private var values: [Bool]
+    private var last: Bool
+    init(values: [Bool]) {
+        self.values = values
+        self.last = values.last ?? false
+    }
+    func next() -> Bool {
+        if values.isEmpty { return last }
+        let v = values.removeFirst()
+        last = v
+        return v
+    }
+}

--- a/Packages/GitHubKit/Sources/GitHubKit/Models/Repository.swift
+++ b/Packages/GitHubKit/Sources/GitHubKit/Models/Repository.swift
@@ -9,6 +9,11 @@ public struct Repository: Identifiable, Codable, Hashable, Sendable {
     public var hasWorkflows: Bool
     public let accountID: UUID
     public var pushedAt: Date?
+    /// Set to true when the repo has been confirmed missing on GitHub
+    /// (deleted, transferred, or renamed). Populated by AppState after
+    /// repeated 404s during polling; persisted so the UI can offer a
+    /// prune action across launches.
+    public var isMissing: Bool
 
     public init(
         id: Int,
@@ -18,7 +23,8 @@ public struct Repository: Identifiable, Codable, Hashable, Sendable {
         isMonitored: Bool = false,
         hasWorkflows: Bool = false,
         accountID: UUID,
-        pushedAt: Date? = nil
+        pushedAt: Date? = nil,
+        isMissing: Bool = false
     ) {
         self.id = id
         self.fullName = fullName
@@ -28,5 +34,23 @@ public struct Repository: Identifiable, Codable, Hashable, Sendable {
         self.hasWorkflows = hasWorkflows
         self.accountID = accountID
         self.pushedAt = pushedAt
+        self.isMissing = isMissing
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, fullName, defaultBranch, isPrivate, isMonitored, hasWorkflows, accountID, pushedAt, isMissing
+    }
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try c.decode(Int.self, forKey: .id)
+        self.fullName = try c.decode(String.self, forKey: .fullName)
+        self.defaultBranch = try c.decode(String.self, forKey: .defaultBranch)
+        self.isPrivate = try c.decode(Bool.self, forKey: .isPrivate)
+        self.isMonitored = try c.decodeIfPresent(Bool.self, forKey: .isMonitored) ?? false
+        self.hasWorkflows = try c.decodeIfPresent(Bool.self, forKey: .hasWorkflows) ?? false
+        self.accountID = try c.decode(UUID.self, forKey: .accountID)
+        self.pushedAt = try c.decodeIfPresent(Date.self, forKey: .pushedAt)
+        self.isMissing = try c.decodeIfPresent(Bool.self, forKey: .isMissing) ?? false
     }
 }


### PR DESCRIPTION
Closes #19

- StatusPoller surfaces 404s distinctly via PollResult { notFoundRepoIDs, successfulRepoIDs }
- 404s skip the token-refresh retry path
- AppState tracks per-repo 404 streak in memory; flips Repository.isMissing after 3 consecutive
- Schema bumped to v2; isMissing persists via existing Repository Codable
- RepoRowView shows dimmed warning + inline Remove for missing repos
- Tests cover partition, no-refresh-on-404, and streak/reset semantics