### PR TITLE
Extract shared helpers to reduce code duplication

### DIFF
--- a/App/AppState.swift
+++ b/App/AppState.swift
@@ -138,6 +138,14 @@ final class AppState {
         return Date().timeIntervalSince(lastUpdated) > 2 * pollIntervalSeconds
     }
 
+    var hasMonitoredRepos: Bool {
+        repositories.contains { $0.isMonitored }
+    }
+
+    var hasPollableRepos: Bool {
+        repositories.contains { $0.isMonitored && $0.hasWorkflows }
+    }
+
     /// Optional callback fired when a repo transitions to or from failure.
     var onStatusChange: ((Int, StatusChangeEvent) -> Void)?
 
@@ -197,9 +205,8 @@ final class AppState {
 
         // Re-check workflow flags: immediately if none have workflows (broken state),
         // otherwise periodically every 5 poll cycles to pick up changes.
-        let hasAnyWorkflowRepos = repositories.contains { $0.isMonitored && $0.hasWorkflows }
         pollCyclesSinceWorkflowRefresh += 1
-        if !hasAnyWorkflowRepos || pollCyclesSinceWorkflowRefresh >= 5 {
+        if !hasPollableRepos || pollCyclesSinceWorkflowRefresh >= 5 {
             pollCyclesSinceWorkflowRefresh = 0
             refreshWorkflowFlags()
         }
@@ -278,8 +285,7 @@ final class AppState {
                     func submitNext() {
                         guard let resp = iterator.next() else { return }
                         group.addTask {
-                            let parts = resp.fullName.split(separator: "/")
-                            guard parts.count == 2 else {
+                            guard let (owner, name) = resp.ownerAndName else {
                                 return Repository(
                                     id: resp.id, fullName: resp.fullName,
                                     defaultBranch: resp.defaultBranch, isPrivate: resp.isPrivate,
@@ -287,7 +293,7 @@ final class AppState {
                                 )
                             }
                             let has = (try? await client.fetchHasWorkflows(
-                                owner: String(parts[0]), repo: String(parts[1])
+                                owner: owner, repo: name
                             )) ?? false
                             return Repository(
                                 id: resp.id, fullName: resp.fullName,
@@ -469,12 +475,11 @@ final class AppState {
             var pendingUpdates: [Int: Bool] = [:]
             for repo in reposToCheck {
                 guard let client = clients[repo.accountID] else { continue }
-                let parts = repo.fullName.split(separator: "/")
-                guard parts.count == 2 else { continue }
+                guard let (owner, name) = repo.ownerAndName else { continue }
 
                 // Only update on success; preserve existing value on failure
                 do {
-                    let has = try await client.fetchHasWorkflows(owner: String(parts[0]), repo: String(parts[1]))
+                    let has = try await client.fetchHasWorkflows(owner: owner, repo: name)
                     pendingUpdates[repo.id] = has
                 } catch {
                     errorMessage = error.localizedDescription

--- a/App/Localizable.xcstrings
+++ b/App/Localizable.xcstrings
@@ -121,11 +121,14 @@
     "CI Status" : {
       "comment" : "Popover header title"
     },
-    "Console" : {
-
-    },
     "Copied!" : {
       "comment" : "Copy device code button after copying"
+    },
+    "Copies a subsystem filter to your clipboard — paste it into Console's search field." : {
+
+    },
+    "Copies this session's logs to your clipboard." : {
+
     },
     "Copy" : {
       "comment" : "Copy device code button"
@@ -135,6 +138,9 @@
     },
     "Deselect All" : {
       "comment" : "Deselect all repos button in section header"
+    },
+    "Diagnostics" : {
+
     },
     "Discard Repositories" : {
       "comment" : "Confirmation dialog option to delete repos when removing account"
@@ -261,6 +267,9 @@
 
     },
     "Offline" : {
+
+    },
+    "Open Console" : {
 
     },
     "Open GitHub" : {

--- a/App/StatusBar/PopoverView.swift
+++ b/App/StatusBar/PopoverView.swift
@@ -148,13 +148,10 @@ struct PopoverView: View {
 
     /// Returns which settings tab the footer should link to, or nil if Refresh should be shown.
     private var footerSettingsTab: AppState.SettingsTab? {
-        if appState.accounts.isEmpty {
+        if appState.accounts.isEmpty || !aggregator.authFailedAccountIDs.isEmpty {
             return .accounts
-        } else if !aggregator.authFailedAccountIDs.isEmpty {
-            return .accounts
-        } else if appState.repositories.filter({ $0.isMonitored }).isEmpty {
-            return .repositories
-        } else if appState.repositories.filter({ $0.isMonitored && $0.hasWorkflows }).isEmpty {
+        }
+        if !appState.hasPollableRepos {
             return .repositories
         }
         return nil
@@ -170,11 +167,11 @@ struct PopoverView: View {
             Text("Offline")
                 .font(.system(size: 11))
                 .foregroundStyle(.orange)
-        } else if appState.repositories.filter({ $0.isMonitored }).isEmpty {
+        } else if !appState.hasMonitoredRepos {
             Text("No repositories selected")
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
-        } else if appState.repositories.filter({ $0.isMonitored && $0.hasWorkflows }).isEmpty {
+        } else if !appState.hasPollableRepos {
             if let error = appState.workflowCheckError {
                 Text(error)
                     .font(.system(size: 11))

--- a/App/Utilities/KeychainHelper.swift
+++ b/App/Utilities/KeychainHelper.swift
@@ -3,63 +3,46 @@ import Security
 
 enum KeychainHelper {
     private static let oauthService = "\(Bundle.main.bundleIdentifier!).oauth"
+    private static let refreshService = "\(Bundle.main.bundleIdentifier!).oauth.refresh"
 
     static func save(token: String, for accountID: UUID) throws {
-        let data = Data(token.utf8)
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: accountID.uuidString,
-            kSecAttrService as String: oauthService,
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
-        ]
-
-        SecItemDelete(query as CFDictionary) // Remove existing if any
-        let status = SecItemAdd(query as CFDictionary, nil)
-        guard status == errSecSuccess else {
-            throw KeychainError.saveFailed(status)
-        }
+        try save(token, service: oauthService, accountID: accountID)
     }
 
     static func loadToken(for accountID: UUID) -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: accountID.uuidString,
-            kSecAttrService as String: oauthService,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
-
-        var result: AnyObject?
-        let status = SecItemCopyMatching(query as CFDictionary, &result)
-        guard status == errSecSuccess, let data = result as? Data else {
-            return nil
-        }
-        return String(data: data, encoding: .utf8)
+        load(service: oauthService, accountID: accountID)
     }
 
     static func deleteToken(for accountID: UUID) {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: accountID.uuidString,
-            kSecAttrService as String: oauthService,
-        ]
-        SecItemDelete(query as CFDictionary)
+        delete(service: oauthService, accountID: accountID)
     }
 
-    // MARK: - Refresh Token
-
-    private static let refreshService = "\(Bundle.main.bundleIdentifier!).oauth.refresh"
-
     static func saveRefreshToken(_ token: String, for accountID: UUID) throws {
-        let data = Data(token.utf8)
-        let query: [String: Any] = [
+        try save(token, service: refreshService, accountID: accountID)
+    }
+
+    static func loadRefreshToken(for accountID: UUID) -> String? {
+        load(service: refreshService, accountID: accountID)
+    }
+
+    static func deleteRefreshToken(for accountID: UUID) {
+        delete(service: refreshService, accountID: accountID)
+    }
+
+    private static func baseQuery(service: String, accountID: UUID) -> [String: Any] {
+        [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: accountID.uuidString,
-            kSecAttrService as String: refreshService,
-            kSecValueData as String: data,
-            kSecAttrAccessible as String: kSecAttrAccessibleWhenUnlockedThisDeviceOnly,
+            kSecAttrService as String: service,
         ]
+    }
+
+    private static func save(_ token: String, service: String, accountID: UUID) throws {
+        var query = baseQuery(service: service, accountID: accountID)
+        query[kSecValueData as String] = Data(token.utf8)
+        query[kSecAttrAccessible as String] = kSecAttrAccessibleWhenUnlockedThisDeviceOnly
+
+        // SecItemAdd fails on duplicate; remove any existing entry first.
         SecItemDelete(query as CFDictionary)
         let status = SecItemAdd(query as CFDictionary, nil)
         guard status == errSecSuccess else {
@@ -67,14 +50,11 @@ enum KeychainHelper {
         }
     }
 
-    static func loadRefreshToken(for accountID: UUID) -> String? {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: accountID.uuidString,
-            kSecAttrService as String: refreshService,
-            kSecReturnData as String: true,
-            kSecMatchLimit as String: kSecMatchLimitOne,
-        ]
+    private static func load(service: String, accountID: UUID) -> String? {
+        var query = baseQuery(service: service, accountID: accountID)
+        query[kSecReturnData as String] = true
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
         guard status == errSecSuccess, let data = result as? Data else {
@@ -83,12 +63,8 @@ enum KeychainHelper {
         return String(data: data, encoding: .utf8)
     }
 
-    static func deleteRefreshToken(for accountID: UUID) {
-        let query: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrAccount as String: accountID.uuidString,
-            kSecAttrService as String: refreshService,
-        ]
+    private static func delete(service: String, accountID: UUID) {
+        let query = baseQuery(service: service, accountID: accountID)
         SecItemDelete(query as CFDictionary)
     }
 

--- a/App/Utilities/NotificationManager.swift
+++ b/App/Utilities/NotificationManager.swift
@@ -17,35 +17,44 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
     }
 
     func notifyBuildFailure(repo: Repository, buildURL: URL?) {
-        guard UserDefaults.standard.bool(forKey: "showNotifications"),
-              UserDefaults.standard.bool(forKey: "notifyOnFailure") else { return }
-
-        let content = UNMutableNotificationContent()
-        content.title = "Build Failed"
-        content.body = "\(repo.fullName) on \(repo.defaultBranch)"
-        content.sound = .default
-        if UserDefaults.standard.bool(forKey: "notifyGrouping") {
-            content.threadIdentifier = "build-status"
-        }
-        if let url = buildURL {
-            content.userInfo = ["url": url.absoluteString]
-        }
-
-        let request = UNNotificationRequest(
-            identifier: "build-failure-\(repo.id)",
-            content: content,
-            trigger: nil
+        guard shouldNotify(for: "notifyOnFailure") else { return }
+        let content = makeContent(
+            title: "Build Failed",
+            body: "\(repo.fullName) on \(repo.defaultBranch)",
+            buildURL: buildURL
         )
-        UNUserNotificationCenter.current().add(request)
+        add(content, identifier: "build-failure-\(repo.id)")
     }
 
     func notifyBuildFixed(repo: Repository, buildURL: URL?) {
-        guard UserDefaults.standard.bool(forKey: "showNotifications"),
-              UserDefaults.standard.bool(forKey: "notifyOnFixed") else { return }
+        guard shouldNotify(for: "notifyOnFixed") else { return }
+        let content = makeContent(
+            title: "Build Fixed",
+            body: "\(repo.fullName) on \(repo.defaultBranch)",
+            buildURL: buildURL
+        )
+        add(content, identifier: "build-fixed-\(repo.id)")
+    }
 
+    func notifyMultipleFailures(count: Int) {
+        guard shouldNotify(for: "notifyOnFailure") else { return }
+        let content = makeContent(
+            title: "Multiple Build Failures",
+            body: "\(count) repos failing",
+            buildURL: nil
+        )
+        add(content, identifier: "build-failure-summary")
+    }
+
+    private func shouldNotify(for preferenceKey: String) -> Bool {
+        UserDefaults.standard.bool(forKey: "showNotifications")
+            && UserDefaults.standard.bool(forKey: preferenceKey)
+    }
+
+    private func makeContent(title: String, body: String, buildURL: URL?) -> UNMutableNotificationContent {
         let content = UNMutableNotificationContent()
-        content.title = "Build Fixed"
-        content.body = "\(repo.fullName) on \(repo.defaultBranch)"
+        content.title = title
+        content.body = body
         content.sound = .default
         if UserDefaults.standard.bool(forKey: "notifyGrouping") {
             content.threadIdentifier = "build-status"
@@ -53,32 +62,11 @@ final class NotificationManager: NSObject, UNUserNotificationCenterDelegate {
         if let url = buildURL {
             content.userInfo = ["url": url.absoluteString]
         }
-
-        let request = UNNotificationRequest(
-            identifier: "build-fixed-\(repo.id)",
-            content: content,
-            trigger: nil
-        )
-        UNUserNotificationCenter.current().add(request)
+        return content
     }
 
-    func notifyMultipleFailures(count: Int) {
-        guard UserDefaults.standard.bool(forKey: "showNotifications"),
-              UserDefaults.standard.bool(forKey: "notifyOnFailure") else { return }
-
-        let content = UNMutableNotificationContent()
-        content.title = "Multiple Build Failures"
-        content.body = "\(count) repos failing"
-        content.sound = .default
-        if UserDefaults.standard.bool(forKey: "notifyGrouping") {
-            content.threadIdentifier = "build-status"
-        }
-
-        let request = UNNotificationRequest(
-            identifier: "build-failure-summary",
-            content: content,
-            trigger: nil
-        )
+    private func add(_ content: UNMutableNotificationContent, identifier: String) {
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: nil)
         UNUserNotificationCenter.current().add(request)
     }
 

--- a/App/Views/AccountsTab.swift
+++ b/App/Views/AccountsTab.swift
@@ -372,10 +372,18 @@ struct AccountsTab: View {
                     let batchResults: [Repository] = await withTaskGroup(of: Repository.self) { group in
                         for resp in batch {
                             group.addTask {
-                                let parts = resp.fullName.split(separator: "/")
-                                let owner = String(parts[0])
-                                let repoName = String(parts[1])
-                                let has = (try? await client.fetchHasWorkflows(owner: owner, repo: repoName)) ?? false
+                                guard let (owner, name) = resp.ownerAndName else {
+                                    return Repository(
+                                        id: resp.id,
+                                        fullName: resp.fullName,
+                                        defaultBranch: resp.defaultBranch,
+                                        isPrivate: resp.isPrivate,
+                                        hasWorkflows: false,
+                                        accountID: account.id,
+                                        pushedAt: resp.pushedAt
+                                    )
+                                }
+                                let has = (try? await client.fetchHasWorkflows(owner: owner, repo: name)) ?? false
                                 return Repository(
                                     id: resp.id,
                                     fullName: resp.fullName,

--- a/Packages/CIStatusKit/Sources/CIStatusKit/StatusPoller.swift
+++ b/Packages/CIStatusKit/Sources/CIStatusKit/StatusPoller.swift
@@ -256,9 +256,9 @@ public actor StatusPoller {
             return BuildStatus(status: .unknown, buildURL: nil, updatedAt: .distantPast, source: .combined)
         }
 
-        let parts = repo.fullName.split(separator: "/")
-        let owner = String(parts[0])
-        let repoName = String(parts[1])
+        guard let (owner, repoName) = repo.ownerAndName else {
+            return BuildStatus(status: .unknown, buildURL: nil, updatedAt: .distantPast, source: .combined)
+        }
 
         // Fetch both concurrently but independently — one failing shouldn't cancel the other.
         // Auth (401) and rate limit errors are rethrown so the caller can report them.

--- a/Packages/GitHubKit/Sources/GitHubKit/Models/Repository.swift
+++ b/Packages/GitHubKit/Sources/GitHubKit/Models/Repository.swift
@@ -29,4 +29,14 @@ public struct Repository: Identifiable, Codable, Hashable, Sendable {
         self.accountID = accountID
         self.pushedAt = pushedAt
     }
+
+    public var ownerAndName: (owner: String, name: String)? {
+        Self.parseOwnerAndName(from: fullName)
+    }
+
+    static func parseOwnerAndName(from fullName: String) -> (owner: String, name: String)? {
+        let parts = fullName.split(separator: "/")
+        guard parts.count == 2 else { return nil }
+        return (String(parts[0]), String(parts[1]))
+    }
 }

--- a/Packages/GitHubKit/Sources/GitHubKit/Models/RepositoryResponse.swift
+++ b/Packages/GitHubKit/Sources/GitHubKit/Models/RepositoryResponse.swift
@@ -16,4 +16,8 @@ public struct RepositoryResponse: Codable, Sendable {
         case isPrivate = "private"
         case pushedAt
     }
+
+    public var ownerAndName: (owner: String, name: String)? {
+        Repository.parseOwnerAndName(from: fullName)
+    }
 }


### PR DESCRIPTION
## Summary

Refactor identified by a duplication scan. No behavior changes on the happy path; two latent force-unwrap crashes (pathological `fullName` without `/`) now fall through safely.

- `Repository.ownerAndName` + `RepositoryResponse` shim in GitHubKit — replaces four copy-pasted `fullName.split("/")` sites
- `KeychainHelper.baseQuery` + private `save`/`load`/`delete` — collapses six duplicated query dictionaries
- `NotificationManager.makeContent` / `shouldNotify(for:)` / `add` helpers — collapses three duplicated notification setups
- `AppState.hasMonitoredRepos` / `hasPollableRepos` — simplifies `PopoverView.footerSettingsTab` from 4 branches to 2 and removes filter duplication from `footerStatus`

Net: +113/-125 across 8 files.

## Test plan

- [x] `cd Packages/GitHubKit && swift test` — 27/27 pass
- [x] `cd Packages/CIStatusKit && swift test` — 19/19 pass
- [x] `xcodebuild build -project Vigilant/Vigilant.xcodeproj -scheme Vigilant` — BUILD SUCCEEDED
- [ ] Smoke-test in Xcode: add account, view popover footer in each state (no accounts, auth failed, no monitored repos, no workflows, healthy)

Closes #38